### PR TITLE
Fix coordinate order

### DIFF
--- a/gomoku/agent/base.py
+++ b/gomoku/agent/base.py
@@ -25,7 +25,7 @@ class BaseAgent(metaclass=ABCMeta):
 
 class RandomAgent(BaseAgent):
     def move(self, board: GomokuBoard) -> np.array:
-        return random.choice(np.array(np.where(board.get_board() == 0)).T)
+        return random.choice(board.get_valid_moves())
 
 class ConsoleAgent(BaseAgent):
     def move(self, board: GomokuBoard) -> np.array:

--- a/gomoku/agent/base.py
+++ b/gomoku/agent/base.py
@@ -25,15 +25,15 @@ class BaseAgent(metaclass=ABCMeta):
 
 class RandomAgent(BaseAgent):
     def move(self, board: GomokuBoard) -> np.array:
-        return np.flip(random.choice(np.array(np.where(board.get_board() == 0)).T))
+        return random.choice(np.array(np.where(board.get_board() == 0)).T)
 
 class ConsoleAgent(BaseAgent):
     def move(self, board: GomokuBoard) -> np.array:
         while True:
-            print(f'Player {self._side}, type your next move! Format: [x-coord],[y-coord]')
+            print(f'Player {self._side}, type your next move! Format: [row],[column]')
             user_input = input()
             try:
                 coords = str(user_input).split(',')
                 return np.array([int(coords[0]), int(coords[1])])
             except:
-                print('Invalid input! Format: [x-coord],[y-coord]')
+                print('Invalid input! Format: [row],[column]')

--- a/gomoku/agent/greedy.py
+++ b/gomoku/agent/greedy.py
@@ -35,8 +35,8 @@ def get_greedy_move(board: GomokuBoard, side: int) -> np.array:
     in four directions (horizontal, vertical, and two diagonals).
 
     These slots are represented by a 4xNxN array, where N is the size
-    of the board. Each value (i,x,y) represents a slot starting at
-    (x,y) going in the ith direction. (Note that some of these slots
+    of the board. Each value (i,r,c) represents a slot starting at
+    (r,c) going in the ith direction. (Note that some of these slots
     are invalid since parts of the slot go off the board.)
 
     The value of this array, represented in bits, consists of two parts.
@@ -68,7 +68,7 @@ def get_greedy_move(board: GomokuBoard, side: int) -> np.array:
         for col in range(board.get_size()):
             for dir_idx, direction in enumerate(DIRECTIONS):
                 for offset in range(NUM_REQUIRED):
-                    base = np.array([col, row]) + direction * offset
+                    base = np.array([row, col]) + direction * offset
 
                     # if agent's piece is found, add 32 and raise flag
                     if board.get_piece(base) == side:
@@ -89,7 +89,7 @@ def get_greedy_move(board: GomokuBoard, side: int) -> np.array:
             for offset in range(5):
                 # find a remaining coordinate from the slot
                 if flags & (1 << offset) == 0:
-                    coord = np.array([col, row]) + offset * DIRECTIONS[dir]
+                    coord = np.array([row, col]) + offset * DIRECTIONS[dir]
                     potential_moves.append(coord)
 
         if potential_moves:
@@ -109,7 +109,7 @@ def get_greedy_move(board: GomokuBoard, side: int) -> np.array:
             return np.array(random.choice(max_moves)), piece_count + 1
 
     # fallback: should only reach when player cannot win any more
-    return np.flip(random.choice(np.array(np.where(board.get_board() == 0)).T)), 0
+    return random.choice(np.array(np.where(board.get_board() == 0)).T), 0
 
 class GreedyAgent(BaseAgent):
     def move(self, board: GomokuBoard) -> np.array:

--- a/gomoku/agent/greedy.py
+++ b/gomoku/agent/greedy.py
@@ -109,7 +109,7 @@ def get_greedy_move(board: GomokuBoard, side: int) -> np.array:
             return np.array(random.choice(max_moves)), piece_count + 1
 
     # fallback: should only reach when player cannot win any more
-    return random.choice(np.array(np.where(board.get_board() == 0)).T), 0
+    return random.choice(board.get_valid_moves()), 0
 
 class GreedyAgent(BaseAgent):
     def move(self, board: GomokuBoard) -> np.array:

--- a/gomoku/board.py
+++ b/gomoku/board.py
@@ -29,7 +29,7 @@ class GomokuBoard:
         for row in range(self.__size):
             for col in range(self.__size):
                 for dir_idx, direction in enumerate(DIRECTIONS):
-                    base = np.array([col, row]) + direction * (NUM_REQUIRED - 1)
+                    base = np.array([row, col]) + direction * (NUM_REQUIRED - 1)
                     if not self.is_on_board(base):
                         self.__blocked_black[dir_idx, row, col] = True
                         self.__blocked_white[dir_idx, row, col] = True
@@ -48,7 +48,7 @@ class GomokuBoard:
             return False
 
         # place piece on board
-        self.__board[coord[1], coord[0]] = side.value
+        self.__board[coord[0], coord[1]] = side.value
         if not self.__quiet:
             print(f'Placed {side} at {coord}')
             print(self)
@@ -59,9 +59,9 @@ class GomokuBoard:
                 base = np.array(coord) - direction * offset
                 if self.is_on_board(base):
                     if side == Side.BLACK:
-                        self.__blocked_black[dir_idx, base[1], base[0]] = True
+                        self.__blocked_black[dir_idx, base[0], base[1]] = True
                     else:
-                        self.__blocked_white[dir_idx, base[1], base[0]] = True
+                        self.__blocked_white[dir_idx, base[0], base[1]] = True
         return True
 
     def is_on_board(self, coord: np.array) -> bool:
@@ -74,7 +74,7 @@ class GomokuBoard:
     def get_piece(self, coord: np.array) -> Side:
         if not self.is_on_board(coord):
             return Side.NONE
-        result = Side(self.__board[coord[1], coord[0]])
+        result = Side(self.__board[coord[0], coord[1]])
         assert result.is_piece()
         return result
 

--- a/gomoku/board.py
+++ b/gomoku/board.py
@@ -71,6 +71,9 @@ class GomokuBoard:
     def is_valid_move(self, coord: np.array) -> bool:
         return self.is_on_board(coord) and not self.get_piece(coord).is_player()
 
+    def get_valid_moves(self) -> np.array:
+        return np.array(np.where(self.__board == Side.NONE.value)).T
+
     def get_piece(self, coord: np.array) -> Side:
         if not self.is_on_board(coord):
             return Side.NONE


### PR DESCRIPTION
Since coordinates were treated as (x,y), and a numpy array is printed in the opposite order,
it wasn't clear when coordinates should be flipped in which situations, which was causing confusion.

Now we treat coordinates as (row, column) so we never flip the order.